### PR TITLE
Added stuff that should upset IaC Analysis

### DIFF
--- a/prova sicurezza/kubernetes/deployment.yaml
+++ b/prova sicurezza/kubernetes/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vulnerable-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vulnerable-app
+  template:
+    metadata:
+      labels:
+        app: vulnerable-app
+    spec:
+      containers:
+      - name: vulnerable-app
+        image: nginx:1.16  # Old image version
+        ports:
+        - containerPort: 80
+        securityContext:
+          privileged: true  # Privileged container (flagged as insecure)

--- a/prova sicurezza/terraform/main.tf
+++ b/prova sicurezza/terraform/main.tf
@@ -1,0 +1,12 @@
+# Example Terraform file with a security misconfiguration
+resource "aws_security_group" "test" {
+  name        = "test-security-group"
+  description = "Allow all inbound traffic"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # Open to the world (flagged as insecure)
+  }
+}


### PR DESCRIPTION
Another absolutely bonkers broken PR. The IaC Analysis stage should go crazy. The only thing is: the IaC stage has exit code 1 (i.e. the pipeline stage fails). Will it still upload the results in SARIF format?